### PR TITLE
Calendar rewrite and refactor

### DIFF
--- a/app/(calendar)/_layout.tsx
+++ b/app/(calendar)/_layout.tsx
@@ -22,6 +22,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AtomiFitShortSVG from "@/components/Svg/AtomiFitShortSVG";
 import UtilityStyles from "@/constants/UtilityStyles";
 import { Entypo, MaterialIcons } from "@expo/vector-icons";
+import { eventEmitter } from "@/utils/eventEmitter";
 
 const { width: SIDEBAR_WIDTH } = Dimensions.get("window");
 
@@ -99,6 +100,22 @@ const CalendarLayout = (): JSX.Element => {
             >
               <Entypo name="menu" size={45} color="black" />
               <AtomiFitShortSVG color={"#0F0F0F"} />
+            </Pressable>
+          </View>
+          <View style={styles.headerButtonsContainer}>
+            <Pressable
+              style={styles.calendarSkipButton}
+              onPress={() => {
+                eventEmitter.emit("calendarReturnToToday");
+              }}
+            >
+              {({ pressed }) => (
+                <MaterialIcons
+                  name="today"
+                  size={32}
+                  color={pressed ? "#2D6823" : "#60DD49"}
+                />
+              )}
             </Pressable>
           </View>
         </View>
@@ -228,6 +245,24 @@ const styles = StyleSheet.create({
   },
   sideButtonText: { fontSize: 28, color: "white" },
   sideButtonTextActive: { fontSize: 28, fontWeight: "bold", color: "#60DD49" },
+  headerButtonsContainer: {
+    flexDirection: "row",
+    height: 64,
+    alignItems: "center",
+    gap: 16,
+    marginRight: 12,
+  },
+  calendarSkipButton: {
+    flexDirection: "row",
+    height: 42,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    backgroundColor: "#292929",
+    borderRadius: 20,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
 });
 
 export default CalendarLayout;

--- a/app/(calendar)/calendar.tsx
+++ b/app/(calendar)/calendar.tsx
@@ -1,378 +1,363 @@
-import { memo, useContext, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, Pressable } from "react-native";
-import { Entypo } from "@expo/vector-icons";
-import { ScrollView } from "react-native-gesture-handler";
-import * as Localization from "expo-localization";
 import { DrizzleContext } from "@/contexts/drizzleContext";
+import { getContrastTextColour } from "@/utils/getContrastTextColour";
+import { getToday } from "@/utils/getToday";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import {
+  StyleSheet,
+  Text,
+  TextStyle,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { CalendarList, DateData } from "react-native-calendars";
 import * as schema from "@/database/schema";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
+import { eventEmitter } from "@/utils/eventEmitter";
+import { CalendarListImperativeMethods } from "react-native-calendars/src/calendar-list";
+import { Theme } from "react-native-calendars/src/types";
+import { DayProps } from "react-native-calendars/src/calendar/day";
+import { dateToUTCZero } from "@/utils/dateToUTCZero";
+import { useSettings } from "@/contexts/settingsContext";
+
+interface CategoriesKeys {
+  [key: string]: { key: string; color: string };
+}
+
+interface MarkedDates {
+  [key: string]: { dots: { key: string; color: string }[]; selected: boolean };
+}
+
+interface SelectedDate {
+  [key: string]: {
+    selected: boolean;
+    selectedColor: string;
+    dots: { key: string; color: string }[] | undefined;
+  };
+}
 
 /**
  * Calendar component.
  *
- * This component displays a calendar with localized month names, weekdays, and days of the month.
- * It allows the user to select a year and a specific day.
- * The component also queries a database for exercise categories performed on selected days.
+ * This component displays the calendar screen with a scrollable FlatList calendar.
+ * It allows the user to select a year and a specific day within a span of 100 years prior to
+ * and after the current date to give the impression of a semi-infinite calendar.
+ * The component also queries the database for exercise categories and workouts performed
+ * on selected days and renders multi dot indicators for each category on marked dates
  *
  * @returns {JSX.Element} The rendered Calendar component.
  */
-const Calendar = memo(() => {
-  const userLocale: string = Localization.useLocales()[0].languageTag; // Get the user's locale from their device language settings
-
-  /**
-   * Generates an array of month names based on the user's locale.
-   * Dependencies run whenever the user's locale changes.
-   *
-   * @param {string} userLocale - The locale of the user.
-   * @returns {string[]} An array of localized month names.
-   */
-  const localizedMonths: string[] = useMemo(() => {
-    const formatter: Intl.DateTimeFormat = new Intl.DateTimeFormat(userLocale, {
-      month: "long",
-    });
-    // Generate an array of localized month names
-    return Array.from({ length: 12 }, (_, i) =>
-      formatter.format(new Date(Date.UTC(2024, i, 1)))
-    );
-  }, [userLocale]);
-
-  const startOfWeek = 1; // 1 = Monday, 7 = Sunday, this will be moved to user settings in the future
-
-  // Store selected year in state, Current year default
-  const [selectedYear, setSelectedYear] = useState<number>(
-    new Date().getFullYear()
-  );
-  // Store selected day in state, format of `month.name-day` (0-based index) and default to current month and day
-  const [selectedDay, setSelectedDay] = useState<string>(() => {
-    const date = new Date();
-    return `${localizedMonths[date.getMonth()]}-${date.getDate()}`;
+const Calendar = (): JSX.Element => {
+  const [selectedDate, setSelectedDate] = useState<SelectedDate>({
+    [dateToUTCZero(new Date(getToday())).toISOString().split("T")[0]]: {
+      selected: true,
+      selectedColor: "#60DD49",
+      dots: [],
+    },
   });
-  // Database query data
-  const [data, setData] = useState<{ date: string; categories: string[] }[]>(
-    []
-  );
+  const [categoriesKeys, setCategoriesKeys] = useState<CategoriesKeys>({});
+  const [workouts, setWorkouts] = useState<MarkedDates>({});
+  const calendarRef = useRef<CalendarListImperativeMethods>(null);
   const { db } = useContext(DrizzleContext);
+  const { appSettings } = useSettings();
 
   useEffect(() => {
-    // Query the database for the categories of exercises performed
-    // SELECT date, ['category1', 'category2', ...] AS categories FROM ...
-    // date is formatted as 'YYYY-MM-DD' and categories is a stringified array of category colours
-    // FROM sets_data JOIN exercises on id JOIN categories on id GROUP BY date
-    const queryData: { date: string; categories: string }[] = db
-      .select({
-        date: sql`STRFTIME('%Y-%m-%d', date) AS date`,
-        categories: sql`'[' || GROUP_CONCAT(formatted_data.formatted_category, ',') || ']' AS categories`,
-      })
-      .from(
-        db
-          .select({
-            date: sql`STRFTIME('%Y-%m-%d', date) AS date`,
-            formatted_category: sql`'"' || categories.colour || '"' AS formatted_category`,
-          })
-          .from(schema.setsData)
-          .leftJoin(
-            schema.exercises,
-            eq(schema.setsData.exercise_id, schema.exercises.id)
-          )
-          .leftJoin(
-            schema.categories,
-            eq(schema.exercises.category_id, schema.categories.id)
-          )
-          .groupBy(
-            sql`STRFTIME('%Y-%m-%d', sets_data.date)`,
-            schema.categories.name
-          )
-          .as("formatted_data")
-      )
-      .groupBy(sql`strftime('%Y-%m-%d', date)`)
-      .all() as { date: string; categories: string }[];
+    eventEmitter.on("calendarReturnToToday", () => {
+      setSelectedDate(() => {
+        const today = dateToUTCZero(new Date(getToday())).toISOString().split("T")[0]
+        if (workouts[today]) {
+          return {
+            [today]: {
+              selected: true,
+              selectedColor: "#60DD49",
+              dots: workouts[today].dots,
+            },
+          };
+        }
+        return {
+          [today]: {
+            selected: true,
+            selectedColor: "#60DD49",
+            dots: [],
+          },
+        };
+      });
+      calendarRef.current?.scrollToMonth(getToday());
+    });
 
-    setData(
-      // Map over the data and parse the stringified psuedo-array back into an array
-      // This is a more performant solution to navigating SQLite shortcomings
-      queryData.map((item) => ({
-        ...item,
-        categories: JSON.parse(item.categories),
-      }))
-    );
+    return () => {
+      eventEmitter.off("calendarReturnToToday", () => {
+        setSelectedDate(() => {
+          const today = dateToUTCZero(new Date(getToday())).toISOString().split("T")[0]
+          if (workouts[today]) {
+            return {
+              [today]: {
+                selected: true,
+                selectedColor: "#60DD49",
+                dots: workouts[today].dots,
+              },
+            };
+          }
+          return {
+            [today]: {
+              selected: true,
+              selectedColor: "#60DD49",
+              dots: [],
+            },
+          };
+        });
+        calendarRef.current?.scrollToMonth(getToday());
+      });
+    };
   }, []);
 
-  /**
-   * Generates an array of short weekday names based on the user's locale.
-   * Dependencies run whenever the user's locale or selected week start changes.
-   *
-   * @param {string} userLocale - The locale of the user.
-   * @returns {string[]} An array of localized short weekday names.
-   */
-  const localizedDays: string[] = useMemo(() => {
-    const formatter: Intl.DateTimeFormat = new Intl.DateTimeFormat(userLocale, {
-      weekday: "short",
-    });
-    // Generate an array of localized short weekday names
-    return Array.from({ length: 7 }, (_, i) =>
-      // i + startOfWeek will order the weekdays by the users selection, default is Monday (1)
-      formatter.format(new Date(Date.UTC(2024, 0, i + startOfWeek)))
-    );
-  }, [userLocale, startOfWeek]);
+  useEffect(() => {
+    const getCategories = async () => {
+      const categories: { id: number; name: string; colour: string }[] =
+        await db.select().from(schema.categories);
 
-  /**
-   * Generates an array of days in a given month.
-   *
-   * @param {number} month - The month number (0-11).
-   * @returns {(number | null)[]} An array of days in the month, including leading and trailing nulls.
-   */
-  const generateDaysInMonth = (month: number): (number | null)[] => {
-    // Pull the number of the last day of the previous month to get a count of days
-    const daysInMonth = new Date(selectedYear, month + 1, 0).getDate();
-    const adjustedFirstDay =
-      (new Date(selectedYear, month, 1).getDay() - startOfWeek + 7) % 7; // Adjust to start on the selected startOfWeek
-    const totalDays = daysInMonth + adjustedFirstDay; // Total number of days in that month including leading nulls to be but not trailing
+      const categoriesMarkingVariants = categories.reduce<CategoriesKeys>(
+        (acc, category) => {
+          if (!acc[category.name]) {
+            acc[category.name] = {
+              key: category.name,
+              color: category.colour,
+            };
+          }
 
-    const rows = Math.ceil(totalDays / 7); // Number of rows to display that month
-    const days = [];
-    for (let i = 0; i < rows * 7; i++) {
-      days.push(
-        // If i is within the range of the month, return the day, else return null including leading and trailing null
-        i >= adjustedFirstDay && i < adjustedFirstDay + daysInMonth
-          ? i - adjustedFirstDay + 1
-          : null
+          return acc;
+        },
+        {}
       );
-    }
-    return days;
+
+      setCategoriesKeys(categoriesMarkingVariants);
+    };
+    getCategories();
+  }, []);
+
+  useEffect(() => {
+    const getWorkouts = async () => {
+      const data = await db
+        .select({
+          id: schema.setsData.id,
+          date: schema.setsData.date,
+          category_name: schema.categories.name,
+        })
+        .from(schema.setsData)
+        .leftJoin(
+          schema.exercises,
+          eq(schema.setsData.exercise_id, schema.exercises.id)
+        )
+        .leftJoin(
+          schema.categories,
+          eq(schema.exercises.category_id, schema.categories.id)
+        );
+
+      const markedDates = data.reduce<MarkedDates>((acc, workout) => {
+        const date = dateToUTCZero(new Date(workout.date))
+          .toISOString()
+          .split("T")[0];
+
+        if (!acc[date]) {
+          acc[date] = {
+            dots: [categoriesKeys[workout.category_name!]],
+            selected: false,
+          };
+        }
+
+        if (acc[date]) {
+          if (
+            !acc[date].dots.find(
+              (dot) => dot.key === categoriesKeys[workout.category_name!].key
+            )
+          ) {
+            acc[date].dots.push(categoriesKeys[workout.category_name!]);
+          }
+        }
+
+        return acc;
+      }, {});
+
+      // If there are logged workouts for today, select the day from
+      // the marked dates and copy the dots array to the selected date.
+      const today = dateToUTCZero(new Date(getToday()))
+        .toISOString()
+        .split("T")[0];
+
+      if (markedDates[today] && selectedDate[today]) {
+        setSelectedDate({
+          [today]: {
+            selected: true,
+            selectedColor: "#60DD49",
+            dots: markedDates[today].dots,
+          },
+        });
+      }
+      setWorkouts(markedDates);
+    };
+    getWorkouts();
+  }, [categoriesKeys]);
+
+  /**
+   * Handles the event when a day is pressed in the calendar.
+   *
+   * @param {DateData} day - The date data of the pressed day.
+   * @returns {void}
+   */
+  const onDayPress = (day: DateData): void => {
+    setSelectedDate({
+      [day.dateString]: {
+        selected: true,
+        selectedColor: "#60DD49",
+        dots: workouts[day.dateString]?.dots,
+      },
+    });
   };
 
-  /**
-   * Generates an array of months with their corresponding days.
-   * Users the localizedMonths function to query localized month names, superior optimization to localizing in the map.
-   *
-   * @property {string} name - The localized name of the month.
-   * @property {(number | null)[]} days - An array of days in the month, including leading and trailing nulls.
-   * @returns {{ name: string; days: (number | null)[] }[]} An array of objects representing each month, containing the localized month name and an array of days.
-   */
-  const months: { name: string; days: (number | null)[] }[] = useMemo(() => {
-    return Array.from({ length: 12 }, (_, month) => ({
-      // instead of performing this in function just use the localizedMonths result, witchcraft optimization
-      name: localizedMonths[month], // average render down to 0.3ms, lets fucking go
-      days: generateDaysInMonth(month),
-    }));
-  }, [selectedYear, userLocale]);
+  // Custom theme for the calendar, styles used in CustomDay component are set in the stylesheet
+  const theme: Theme = {
+    calendarBackground: "transparent",
+    textMonthFontWeight: "bold" as TextStyle["fontWeight"],
+    textMonthFontSize: 17,
+    dayTextColor: "white",
+    monthTextColor: "white",
+    textSectionTitleColor: "white",
+    todayTextColor: "#60DD49",
+    selectedDayTextColor: getContrastTextColour("#60DD49"),
+  };
 
   return (
-    <>
-      <View style={styles.yearScrollContainer}>
-        <Pressable onPress={() => setSelectedYear((prevYear) => prevYear - 1)}>
-          {({ pressed }) => (
-            <Entypo
-              name="chevron-thin-left"
-              size={30}
-              color={pressed ? "#2D6823" : "#60DD49"}
-            />
-          )}
-        </Pressable>
-        <Text style={styles.yearText}>{selectedYear}</Text>
-        <Pressable onPress={() => setSelectedYear((prevYear) => prevYear + 1)}>
-          {({ pressed }) => (
-            <Entypo
-              name="chevron-thin-right"
-              size={30}
-              color={pressed ? "#2D6823" : "#60DD49"}
-            />
-          )}
-        </Pressable>
-      </View>
-      <ScrollView>
-        {months.map((month, monthIndex) => (
-          <View key={`${month.name}`} style={styles.monthContainer}>
-            <Text style={styles.monthName}>{month.name}</Text>
-            <View style={styles.monthWeeksContainer}>
-              <View style={styles.daysContainer}>
-                {localizedDays.map((dayName, _) => (
-                  <Text
-                    key={`${month.name}-${dayName}`}
-                    style={styles.weekDays}
-                  >
-                    {dayName.toLocaleUpperCase()}
-                  </Text>
-                ))}
-              </View>
-              {month.days
-                // Chunk the days into weeks, far more efficient than the previous method of chunking while generating
-                .reduce<(number | null)[][]>((weeks, day, i) => {
-                  // Calculate the week index based on the day index, this stops us from having
-                  // to calculate every 7 items as if we were chunking with a for loop
-                  const weekIndex = Math.floor(i / 7);
-                  // Initialize the week if it doesn't exist
-                  if (!weeks[weekIndex]) {
-                    weeks[weekIndex] = [];
-                  }
-                  weeks[weekIndex].push(day); // Push the day into the week chunk before we go again
-                  return weeks;
-                }, [])
-                // Map the week chunks into JSX
-                .map((week, weekIndex) => (
-                  <View
-                    key={`${month.name}-${weekIndex}`}
-                    style={styles.daysContainer}
-                  >
-                    {week.map((day, dayIndex) => {
-                      if (day !== null) {
-                        return (
-                          <Pressable
-                            key={`${month.name}-${day}-${dayIndex}`}
-                            onPress={() =>
-                              day && setSelectedDay(`${month.name}-${day}`)
-                            }
-                            style={[
-                              selectedDay === `${month.name}-${day}` && {
-                                backgroundColor: "#60DD49",
-                              },
-                              styles.dayButton,
-                            ]}
-                          >
-                            <Text style={styles.dayText}>{day}</Text>
-                            {data
-                              // Filter the data to only show the categories for the selected day
-                              .filter(
-                                (item) =>
-                                  item.date ===
-                                  `${selectedYear}-${String(
-                                    monthIndex + 1
-                                  ).padStart(2, "0")}-${String(day).padStart(
-                                    2,
-                                    "0"
-                                  )}`
-                              )
-                              // Filter will return an array of one item so we can just map over it
-                              .map((item) => {
-                                // Create a container for the category indicators
-                                return (
-                                  <View
-                                    key={`${month.name}-${day}-${dayIndex}-categories`}
-                                    style={[
-                                      styles.dayIndicatorContainer,
-                                      // If the day is selected, move the indicator to the bottom
-                                      selectedDay === `${month.name}-${day}`
-                                        ? { top: "104%" }
-                                        : { top: "70%" },
-                                    ]}
-                                  >
-                                    {
-                                      // Map over the categories and create a coloured indicator for each
-                                      item.categories.map((category) => {
-                                        return (
-                                          <View
-                                            key={`${month.name}-${day}-${dayIndex}-${category}`}
-                                            style={[
-                                              styles.dayIndicator,
-                                              { backgroundColor: category },
-                                            ]}
-                                          />
-                                        );
-                                      })
-                                    }
-                                  </View>
-                                );
-                              })}
-                          </Pressable>
-                        );
-                      } else {
-                        // Empty tiles for null days to preserve layout
-                        return (
-                          <View
-                            key={`${month}-${day}-${dayIndex}`}
-                            style={styles.dayBlank}
-                          />
-                        );
-                      }
-                    })}
-                  </View>
-                ))}
-            </View>
-          </View>
-        ))}
-      </ScrollView>
-    </>
+    <CalendarList
+      // I would really REALLY like to know who is going to actively work out for 200 years but we'll do it live
+      // I've explored using FlatList props and such to load more months but it wont work
+      pastScrollRange={1200}
+      futureScrollRange={1200}
+      ref={calendarRef}
+      onDayPress={(day) => onDayPress(day)}
+      markedDates={{ ...workouts, ...selectedDate }}
+      markingType="custom"
+      dayComponent={(props) => <CustomDay {...props} theme={theme} />}
+      theme={theme}
+      firstDay={appSettings?.calendarWeekStart}
+    />
   );
-});
+};
+
+/**
+ * CustomDay component renders a calendar day with optional markings and styles.
+ * The component has custom rendering for multi-dot markings with a function for dynamic
+ * size handling for the wrapping of long lists of dot indicators.
+ *
+ * @param {DayProps & { date?: DateData; }} props - The properties object.
+ * @param {DateData} props.date - The date data object for the day.
+ * @param {DayState} props.state - The day state (e.g., "selected" | "today" | "disabled").
+ * @param {MarkingProps | undefined} props.marking - The marking object containing selected state, color, and dots.
+ * @param {boolean} props.marking.selected - Indicates if the day is selected.
+ * @param {string} props.marking.selectedColor - The color for the selected day.
+ * @param {DOT[]} props.marking.dots - An array of dot objects to display below the day.
+ * @param {((date?: DateData) => void) | undefined} props.onPress - The function to call when the day is pressed.
+ *
+ * @returns {JSX.Element} The rendered CustomDay component.
+ */
+const CustomDay = ({
+  date,
+  state,
+  marking,
+  onPress,
+  theme,
+}: DayProps & {
+  date?: DateData;
+  theme?: Theme;
+}): JSX.Element => {
+  const { selected, selectedColor, dots } = marking || {};
+  const isToday = state === "today";
+
+  /**
+   * Calculates the size of the dots container based on the number of dots to handle wrapping appropriately.
+   *
+   * @returns {number} The size of the dots container.
+   */
+  const sizeDotsContainer = useCallback(() => {
+    if (!dots) return 0;
+    if (dots.length === 5) return 28;
+    if (dots.length === 6) return 24;
+    if (dots.length > 8) return 38;
+    return 32;
+  }, [dots]);
+
+  return (
+    <TouchableOpacity
+      // This will match the accessibility label of the default day component
+      accessibilityLabel={`${new Date(date!.dateString).toLocaleDateString(
+        undefined,
+        {
+          weekday: "long",
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        }
+      )} ${dots?.length ? "workout saved" : ""}`}
+      onPress={() => onPress && onPress(date)}
+      style={[
+        styles.dayContainer,
+        selected && { backgroundColor: selectedColor || "#00BBF2" }, // Default value as a fallback option
+      ]}
+    >
+      <Text
+        allowFontScaling={false}
+        style={[
+          styles.dayText,
+          isToday && { color: theme?.todayTextColor || "#00BBF2" }, // Default value as a fallback option
+          selected && {
+            color: theme?.selectedDayTextColor || "white", // Default value as a fallback option
+          },
+        ]}
+      >
+        {date?.day}
+      </Text>
+      {dots && dots.length > 0 && (
+        <View
+          style={[
+            styles.dotsContainer,
+            { bottom: selected ? -8 : 0, width: sizeDotsContainer() },
+          ]}
+        >
+          {dots.map((dot, index) => (
+            <View
+              key={`${date?.dateString}-${dot.key}-${index}`}
+              style={[styles.dot, { backgroundColor: dot.color }]}
+            />
+          ))}
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
 
 const styles = StyleSheet.create({
-  yearScrollContainer: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "space-between",
-    padding: 4,
+  dayContainer: {
+    width: 32,
+    height: 32,
     alignItems: "center",
-    borderBottomWidth: 1,
-    borderBottomColor: "#60DD49",
-  },
-  yearText: {
-    color: "white",
-    fontSize: 22,
-  },
-  monthContainer: {
-    marginVertical: 20,
-    alignSelf: "center",
-    alignItems: "center",
-    width: "85%",
-  },
-  monthName: {
-    fontSize: 17,
-    fontWeight: "bold",
-    color: "white",
-    marginBottom: 10,
-    alignSelf: "flex-start",
-  },
-  monthWeeksContainer: {
-    width: "100%",
-  },
-  weekDays: {
-    color: "white",
-    fontSize: 13,
-    width: 36,
-    marginBottom: 5,
-    textAlign: "center",
-  },
-  daysContainer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    flexWrap: "wrap",
-  },
-  dayButton: {
-    width: 36,
-    height: 36,
     justifyContent: "center",
-    alignItems: "center",
-    textAlign: "center",
-    // set the background color based on the selected day
-    // {[styles.dayButton, selectedDay is true && {backgroundColor: "#60DD49"}]}
-    borderRadius: 20,
-    marginVertical: 4,
-  },
-  dayBlank: {
-    width: 36,
-    height: 36,
-    marginVertical: 4,
+    borderRadius: 300,
   },
   dayText: {
     color: "white",
-    fontSize: 16,
-    textAlign: "center",
+    fontSize: 15,
+    fontWeight: "400",
   },
-  dayIndicatorContainer: {
-    flexDirection: "row",
+  dotsContainer: {
     position: "absolute",
-    // set the top position based on the selected day
-    // {[styles.dayIndicatorContainer, selectedDay is true ? {top: "104%"} : {top: "70%"}]}
-    gap: 2,
-    justifyContent: "space-evenly",
-    maxWidth: 34,
+    flexDirection: "row",
     flexWrap: "wrap",
+    height: 6, // This makes setting the position consistent and easier to manage for every combination
+    width: 28,
+    justifyContent: "center",
+    gap: 2,
   },
-  dayIndicator: {
+  dot: {
     width: 6,
     height: 6,
-    // set the background color based on the category colour from map
-    // {[styles.dayIndicator, {backgroundColor: category}]}
     borderRadius: 3,
   },
 });

--- a/app/welcome/index.tsx
+++ b/app/welcome/index.tsx
@@ -29,7 +29,7 @@ import PickeriOSButton from "@/components/inputs/pickers/PickeriOSButton";
  * The `index` component is the first screen users are shown when opening the app to set their preferences.
  *
  * @remarks
- * Currently the default unit system and calendar week start (not yet implemented) are the only preferences shown here.
+ * Currently the default unit system and calendar week start are the only preferences shown here.
  * The component uses the `useSettings` custom hook to update app settings in the data store.
  *
  * @returns {JSX.Element} The rendered welcome screen component.
@@ -244,7 +244,7 @@ const index = (): JSX.Element => {
             </View>
             <View>
               <Text style={styles.sectionTitle}>
-                Calendar Week Start (not yet implemented)
+                Calendar Week Start
               </Text>
               {Platform.OS === "ios" ? (
                 <PickeriOSButton

--- a/components/legacy/calendar.tsx
+++ b/components/legacy/calendar.tsx
@@ -1,0 +1,380 @@
+import { memo, useContext, useEffect, useMemo, useState } from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { Entypo } from "@expo/vector-icons";
+import { ScrollView } from "react-native-gesture-handler";
+import * as Localization from "expo-localization";
+import { DrizzleContext } from "@/contexts/drizzleContext";
+import * as schema from "@/database/schema";
+import { eq, sql } from "drizzle-orm";
+
+/**
+ * Calendar component.
+ *
+ * This component displays a calendar with localized month names, weekdays, and days of the month.
+ * It allows the user to select a year and a specific day.
+ * The component also queries a database for exercise categories performed on selected days.
+ *
+ * @returns {JSX.Element} The rendered Calendar component.
+ */
+const Calendar = memo(() => {
+  const userLocale: string = Localization.useLocales()[0].languageTag; // Get the user's locale from their device language settings
+
+  /**
+   * Generates an array of month names based on the user's locale.
+   * Dependencies run whenever the user's locale changes.
+   *
+   * @param {string} userLocale - The locale of the user.
+   * @returns {string[]} An array of localized month names.
+   */
+  const localizedMonths: string[] = useMemo(() => {
+    const formatter: Intl.DateTimeFormat = new Intl.DateTimeFormat(userLocale, {
+      month: "long",
+    });
+    // Generate an array of localized month names
+    return Array.from({ length: 12 }, (_, i) =>
+      formatter.format(new Date(Date.UTC(2024, i, 1)))
+    );
+  }, [userLocale]);
+
+  const startOfWeek = 1; // 1 = Monday, 7 = Sunday, this will be moved to user settings in the future
+
+  // Store selected year in state, Current year default
+  const [selectedYear, setSelectedYear] = useState<number>(
+    new Date().getFullYear()
+  );
+  // Store selected day in state, format of `month.name-day` (0-based index) and default to current month and day
+  const [selectedDay, setSelectedDay] = useState<string>(() => {
+    const date = new Date();
+    return `${localizedMonths[date.getMonth()]}-${date.getDate()}`;
+  });
+  // Database query data
+  const [data, setData] = useState<{ date: string; categories: string[] }[]>(
+    []
+  );
+  const { db } = useContext(DrizzleContext);
+
+  useEffect(() => {
+    // Query the database for the categories of exercises performed
+    // SELECT date, ['category1', 'category2', ...] AS categories FROM ...
+    // date is formatted as 'YYYY-MM-DD' and categories is a stringified array of category colours
+    // FROM sets_data JOIN exercises on id JOIN categories on id GROUP BY date
+    const queryData: { date: string; categories: string }[] = db
+      .select({
+        date: sql`STRFTIME('%Y-%m-%d', date) AS date`,
+        categories: sql`'[' || GROUP_CONCAT(formatted_data.formatted_category, ',') || ']' AS categories`,
+      })
+      .from(
+        db
+          .select({
+            date: sql`STRFTIME('%Y-%m-%d', date) AS date`,
+            formatted_category: sql`'"' || categories.colour || '"' AS formatted_category`,
+          })
+          .from(schema.setsData)
+          .leftJoin(
+            schema.exercises,
+            eq(schema.setsData.exercise_id, schema.exercises.id)
+          )
+          .leftJoin(
+            schema.categories,
+            eq(schema.exercises.category_id, schema.categories.id)
+          )
+          .groupBy(
+            sql`STRFTIME('%Y-%m-%d', sets_data.date)`,
+            schema.categories.name
+          )
+          .as("formatted_data")
+      )
+      .groupBy(sql`strftime('%Y-%m-%d', date)`)
+      .all() as { date: string; categories: string }[];
+
+    setData(
+      // Map over the data and parse the stringified psuedo-array back into an array
+      // This is a more performant solution to navigating SQLite shortcomings
+      queryData.map((item) => ({
+        ...item,
+        categories: JSON.parse(item.categories),
+      }))
+    );
+  }, []);
+
+  /**
+   * Generates an array of short weekday names based on the user's locale.
+   * Dependencies run whenever the user's locale or selected week start changes.
+   *
+   * @param {string} userLocale - The locale of the user.
+   * @returns {string[]} An array of localized short weekday names.
+   */
+  const localizedDays: string[] = useMemo(() => {
+    const formatter: Intl.DateTimeFormat = new Intl.DateTimeFormat(userLocale, {
+      weekday: "short",
+    });
+    // Generate an array of localized short weekday names
+    return Array.from({ length: 7 }, (_, i) =>
+      // i + startOfWeek will order the weekdays by the users selection, default is Monday (1)
+      formatter.format(new Date(Date.UTC(2024, 0, i + startOfWeek)))
+    );
+  }, [userLocale, startOfWeek]);
+
+  /**
+   * Generates an array of days in a given month.
+   *
+   * @param {number} month - The month number (0-11).
+   * @returns {(number | null)[]} An array of days in the month, including leading and trailing nulls.
+   */
+  const generateDaysInMonth = (month: number): (number | null)[] => {
+    // Pull the number of the last day of the previous month to get a count of days
+    const daysInMonth = new Date(selectedYear, month + 1, 0).getDate();
+    const adjustedFirstDay =
+      (new Date(selectedYear, month, 1).getDay() - startOfWeek + 7) % 7; // Adjust to start on the selected startOfWeek
+    const totalDays = daysInMonth + adjustedFirstDay; // Total number of days in that month including leading nulls to be but not trailing
+
+    const rows = Math.ceil(totalDays / 7); // Number of rows to display that month
+    const days = [];
+    for (let i = 0; i < rows * 7; i++) {
+      days.push(
+        // If i is within the range of the month, return the day, else return null including leading and trailing null
+        i >= adjustedFirstDay && i < adjustedFirstDay + daysInMonth
+          ? i - adjustedFirstDay + 1
+          : null
+      );
+    }
+    return days;
+  };
+
+  /**
+   * Generates an array of months with their corresponding days.
+   * Users the localizedMonths function to query localized month names, superior optimization to localizing in the map.
+   *
+   * @property {string} name - The localized name of the month.
+   * @property {(number | null)[]} days - An array of days in the month, including leading and trailing nulls.
+   * @returns {{ name: string; days: (number | null)[] }[]} An array of objects representing each month, containing the localized month name and an array of days.
+   */
+  const months: { name: string; days: (number | null)[] }[] = useMemo(() => {
+    return Array.from({ length: 12 }, (_, month) => ({
+      // instead of performing this in function just use the localizedMonths result, witchcraft optimization
+      name: localizedMonths[month], // average render down to 0.3ms, lets fucking go
+      days: generateDaysInMonth(month),
+    }));
+  }, [selectedYear, userLocale]);
+
+  return (
+    <>
+      <View style={styles.yearScrollContainer}>
+        <Pressable onPress={() => setSelectedYear((prevYear) => prevYear - 1)}>
+          {({ pressed }) => (
+            <Entypo
+              name="chevron-thin-left"
+              size={30}
+              color={pressed ? "#2D6823" : "#60DD49"}
+            />
+          )}
+        </Pressable>
+        <Text style={styles.yearText}>{selectedYear}</Text>
+        <Pressable onPress={() => setSelectedYear((prevYear) => prevYear + 1)}>
+          {({ pressed }) => (
+            <Entypo
+              name="chevron-thin-right"
+              size={30}
+              color={pressed ? "#2D6823" : "#60DD49"}
+            />
+          )}
+        </Pressable>
+      </View>
+      <ScrollView>
+        {months.map((month, monthIndex) => (
+          <View key={`${month.name}`} style={styles.monthContainer}>
+            <Text style={styles.monthName}>{month.name}</Text>
+            <View style={styles.monthWeeksContainer}>
+              <View style={styles.daysContainer}>
+                {localizedDays.map((dayName, _) => (
+                  <Text
+                    key={`${month.name}-${dayName}`}
+                    style={styles.weekDays}
+                  >
+                    {dayName.toLocaleUpperCase()}
+                  </Text>
+                ))}
+              </View>
+              {month.days
+                // Chunk the days into weeks, far more efficient than the previous method of chunking while generating
+                .reduce<(number | null)[][]>((weeks, day, i) => {
+                  // Calculate the week index based on the day index, this stops us from having
+                  // to calculate every 7 items as if we were chunking with a for loop
+                  const weekIndex = Math.floor(i / 7);
+                  // Initialize the week if it doesn't exist
+                  if (!weeks[weekIndex]) {
+                    weeks[weekIndex] = [];
+                  }
+                  weeks[weekIndex].push(day); // Push the day into the week chunk before we go again
+                  return weeks;
+                }, [])
+                // Map the week chunks into JSX
+                .map((week, weekIndex) => (
+                  <View
+                    key={`${month.name}-${weekIndex}`}
+                    style={styles.daysContainer}
+                  >
+                    {week.map((day, dayIndex) => {
+                      if (day !== null) {
+                        return (
+                          <Pressable
+                            key={`${month.name}-${day}-${dayIndex}`}
+                            onPress={() =>
+                              day && setSelectedDay(`${month.name}-${day}`)
+                            }
+                            style={[
+                              selectedDay === `${month.name}-${day}` && {
+                                backgroundColor: "#60DD49",
+                              },
+                              styles.dayButton,
+                            ]}
+                          >
+                            <Text style={styles.dayText}>{day}</Text>
+                            {data
+                              // Filter the data to only show the categories for the selected day
+                              .filter(
+                                (item) =>
+                                  item.date ===
+                                  `${selectedYear}-${String(
+                                    monthIndex + 1
+                                  ).padStart(2, "0")}-${String(day).padStart(
+                                    2,
+                                    "0"
+                                  )}`
+                              )
+                              // Filter will return an array of one item so we can just map over it
+                              .map((item) => {
+                                // Create a container for the category indicators
+                                return (
+                                  <View
+                                    key={`${month.name}-${day}-${dayIndex}-categories`}
+                                    style={[
+                                      styles.dayIndicatorContainer,
+                                      // If the day is selected, move the indicator to the bottom
+                                      selectedDay === `${month.name}-${day}`
+                                        ? { top: "104%" }
+                                        : { top: "70%" },
+                                    ]}
+                                  >
+                                    {
+                                      // Map over the categories and create a coloured indicator for each
+                                      item.categories.map((category) => {
+                                        return (
+                                          <View
+                                            key={`${month.name}-${day}-${dayIndex}-${category}`}
+                                            style={[
+                                              styles.dayIndicator,
+                                              { backgroundColor: category },
+                                            ]}
+                                          />
+                                        );
+                                      })
+                                    }
+                                  </View>
+                                );
+                              })}
+                          </Pressable>
+                        );
+                      } else {
+                        // Empty tiles for null days to preserve layout
+                        return (
+                          <View
+                            key={`${month}-${day}-${dayIndex}`}
+                            style={styles.dayBlank}
+                          />
+                        );
+                      }
+                    })}
+                  </View>
+                ))}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </>
+  );
+});
+
+const styles = StyleSheet.create({
+  yearScrollContainer: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    padding: 4,
+    alignItems: "center",
+    borderBottomWidth: 1,
+    borderBottomColor: "#60DD49",
+  },
+  yearText: {
+    color: "white",
+    fontSize: 22,
+  },
+  monthContainer: {
+    marginVertical: 20,
+    alignSelf: "center",
+    alignItems: "center",
+    width: "85%",
+  },
+  monthName: {
+    fontSize: 17,
+    fontWeight: "bold",
+    color: "white",
+    marginBottom: 10,
+    alignSelf: "flex-start",
+  },
+  monthWeeksContainer: {
+    width: "100%",
+  },
+  weekDays: {
+    color: "white",
+    fontSize: 13,
+    width: 36,
+    marginBottom: 5,
+    textAlign: "center",
+  },
+  daysContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+  },
+  dayButton: {
+    width: 36,
+    height: 36,
+    justifyContent: "center",
+    alignItems: "center",
+    textAlign: "center",
+    // set the background color based on the selected day
+    // {[styles.dayButton, selectedDay is true && {backgroundColor: "#60DD49"}]}
+    borderRadius: 20,
+    marginVertical: 4,
+  },
+  dayBlank: {
+    width: 36,
+    height: 36,
+    marginVertical: 4,
+  },
+  dayText: {
+    color: "white",
+    fontSize: 16,
+    textAlign: "center",
+  },
+  dayIndicatorContainer: {
+    flexDirection: "row",
+    position: "absolute",
+    // set the top position based on the selected day
+    // {[styles.dayIndicatorContainer, selectedDay is true ? {top: "104%"} : {top: "70%"}]}
+    gap: 2,
+    justifyContent: "space-evenly",
+    maxWidth: 34,
+    flexWrap: "wrap",
+  },
+  dayIndicator: {
+    width: 6,
+    height: 6,
+    // set the background color based on the category colour from map
+    // {[styles.dayIndicator, {backgroundColor: category}]}
+    borderRadius: 3,
+  },
+});
+
+export default Calendar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-native": "0.76.2",
+        "react-native-calendars": "^1.1310.0",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-infinite-pager": "^0.3.18",
         "react-native-modal": "^13.0.1",
@@ -13317,6 +13318,16 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -14597,6 +14608,24 @@
         "prop-types": "^15.7.2"
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1310.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1310.0.tgz",
+      "integrity": "sha512-QTcxBDZRLVmoDriQD6vbRXiQ9bMEVtU8Hs7bGC3uJx6fIn+uVcx2V5liry0IwLLiu3tv1V5IHgQ2W/QYDzhMpA==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz",
@@ -14751,6 +14780,12 @@
         "react-native": ">=0.59.0",
         "react-native-svg": ">=12.0.0"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-tab-view": {
       "version": "3.5.2",
@@ -15003,6 +15038,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/regenerate": {
@@ -16791,6 +16841,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -17597,6 +17653,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "drizzle-orm": "^0.36.3",
     "eventemitter3": "^5.0.1",
     "expo": "^52.0.7",
+    "expo-asset": "~11.0.4",
     "expo-drizzle-studio-plugin": "^0.1.1",
+    "expo-file-system": "~18.0.11",
     "expo-font": "~13.0.1",
     "expo-linking": "~7.0.2",
     "expo-localization": "~16.0.0",
@@ -40,6 +42,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.2",
+    "react-native-calendars": "^1.1310.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-infinite-pager": "^0.3.18",
     "react-native-modal": "^13.0.1",
@@ -50,9 +53,7 @@
     "react-native-svg": "15.8.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-web": "~0.19.13",
-    "reanimated-color-picker": "^3.0.6",
-    "expo-asset": "~11.0.4",
-    "expo-file-system": "~18.0.11"
+    "reanimated-color-picker": "^3.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/utils/dateToUTCZero.ts
+++ b/utils/dateToUTCZero.ts
@@ -1,0 +1,16 @@
+/**
+ * Converts a given date to UTC+0 or "Zulu" Time.
+ *
+ * This function takes a Date object and adjusts it to the UTC+0 by
+ * subtracting the timezone offset in minutes from the date's current time.
+ * This is useful for accounting for the timezone offset caused by daylight
+ * savings or meridians where issues are present with these as the cause.
+ *
+ * @param {Date} date - The date to be converted to UTC+0.
+ * @returns {Date} A new Date object set to UTC+0.
+ */
+export const dateToUTCZero = (date: Date): Date => {
+  return new Date(
+    date.setMinutes(date.getMinutes() - date.getTimezoneOffset())
+  );
+};


### PR DESCRIPTION
Rewrite Calendar screen
- Moved old calendar screen into legacy components, there could be some use for that code somewhere in the future
- Added wix/react-native-calendars to packages
- Add new calendar screen with wix CalendarList component and custom day component for control over multi-dot markings (no infinite scroll function, possibility of this being swapped in the future but for now 100 years either side of the current date is the set range)
- Add "scroll to today" button in app/calendar layout
- Add dateToUTCZero util function for fixing timezone and daylight savings errors as the calendar utilizes a yyyy-mm-dd datestring with no time strings or timezone offset leading to errors
- Refactor app/welcome/index to remove not yet implemented text of week start options which are now implemented